### PR TITLE
Drop $(DEPSUBSTVARS) from dh_gencontrol call

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -223,7 +223,7 @@ binary-arch: build install
 	grep shlibs:Suggests debian/monitoring-plugins-standard.substvars.in \
 		| sed -e 's/shlibs:Suggests/shlibs:Recommends/' \
 		>> debian/monitoring-plugins-standard.substvars
-	dh_gencontrol -s -- $(DEPSUBSTVARS)
+	dh_gencontrol -s
 	dh_md5sums -s
 	dh_builddeb -s
 


### PR DESCRIPTION
This has no longer been needed since commit 3ca0202.