### PR TITLE
Drop fping and qstat from Recommends to Suggests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -90,15 +90,15 @@ Breaks: nagios-plugins-standard (<< 1.5-4~)
 Depends: monitoring-plugins-basic, ucf, ${misc:Depends}, ${shlibs:Depends}
 Recommends: bind9-host | host,
             dnsutils,
-            fping,
             libnet-snmp-perl,
-            qstat,
             rpcbind,
             smbclient,
             snmp,
             ${shlibs:Recommends}
-Suggests: icinga | icinga | nagios3,
-          postfix | sendmail-bin | exim4-daemon-heavy | exim4-daemon-light
+Suggests: fping,
+          icinga | icinga | nagios3,
+          postfix | sendmail-bin | exim4-daemon-heavy | exim4-daemon-light,
+          qstat
 Description: Plugins for nagios compatible monitoring systems (standard)
  Plugins for nagios compatible monitoring systems like Naemon and Icinga. It
  contains the following plugins:


### PR DESCRIPTION
As discussed with Jan on IRC. fping and qstat are in universe in Ubuntu,
and requires an extensive delta to add an -extras package in universe
for Ubuntu users to benefit. Instead we can drop the Recommends to a
Suggests in Debian to save Ubuntu from having to do this.